### PR TITLE
Restructure of launch mode logic : wallet pick model appears on top of app now

### DIFF
--- a/src/App/AppMultiversX.tsx
+++ b/src/App/AppMultiversX.tsx
@@ -65,7 +65,7 @@ import { useLocalStorage } from "libs/hooks";
 import {
   CHAIN_TOKEN_SYMBOL,
   CHAINS,
-  clearAppSessions,
+  clearAppSessionsLaunchMode,
   consoleNotice,
   contractsForChain,
   formatNumberRoundFloor,
@@ -277,7 +277,7 @@ function App({ appConfig }: { appConfig: any }) {
   };
 
   const handleLogout = () => {
-    clearAppSessions();
+    clearAppSessionsLaunchMode();
 
     setUser({ ...baseUserContext });
     setChainMeta({});

--- a/src/AppHarness/AppHarnessMultiversX.tsx
+++ b/src/AppHarness/AppHarnessMultiversX.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useGetAccountInfo } from "@multiversx/sdk-dapp/hooks/account";
 import AppMx from "App/AppMultiversX";
+import LandingPage from "Launch/LandingPage";
 
-function AppHarnessMx({ launchEnvironment }: { launchEnvironment: any }) {
+function AppHarnessMx({ launchEnvironment, handleLaunchMode }: { launchEnvironment: any, handleLaunchMode: any }) {
   const { address: mxAddress } = useGetAccountInfo();
 
   return (
@@ -13,7 +14,7 @@ function AppHarnessMx({ launchEnvironment }: { launchEnvironment: any }) {
             mxEnvironment: launchEnvironment,
           }}
         />
-      )}
+      ) || <LandingPage onLaunchMode={handleLaunchMode} />}
     </>
   );
 }

--- a/src/AuthPicker/AuthPickerMultiversX.tsx
+++ b/src/AuthPicker/AuthPickerMultiversX.tsx
@@ -22,16 +22,16 @@ import { ExtensionLoginButton, LedgerLoginButton, WalletConnectLoginButton, WebW
 import { useLocalStorage } from "libs/hooks";
 import { walletConnectV2ProjectId } from "libs/mxConstants";
 import { WALLETS } from "libs/util";
-import { gtagGo, clearAppSessions, sleep } from "libs/util";
+import { gtagGo, clearAppSessionsLaunchMode, sleep } from "libs/util";
 
 function AuthPickerMx({ launchEnvironment, resetLaunchMode }: { launchEnvironment: any; resetLaunchMode: any }) {
   const { address: mxAddress } = useGetAccountInfo();
   const { isOpen: isProgressModalOpen, onOpen: onProgressModalOpen, onClose: onProgressModalClose } = useDisclosure();
-  const [walletUsedSession, setWalletUsedSession] = useLocalStorage("itm-wallet-used", null);
+  const [, setWalletUsedSession] = useLocalStorage("itm-wallet-used", null);
 
   useEffect(() => {
     async function cleanOutRemoteXPortalAppWalletDisconnect() {
-      clearAppSessions();
+      clearAppSessionsLaunchMode();
 
       await sleep(1);
       if (window !== undefined) {
@@ -74,61 +74,59 @@ function AuthPickerMx({ launchEnvironment, resetLaunchMode }: { launchEnvironmen
   return (
     <>
       {!mxAddress && (
-        <Stack spacing={6} p="5">
-          <Modal isCentered size={modelSize} isOpen={isProgressModalOpen} onClose={handleProgressModalClose} closeOnEsc={false} closeOnOverlayClick={false}>
-            <ModalOverlay />
-            <ModalContent>
-              <ModalHeader>
-                Select a{" "}
-                <Badge mb="1" mr="1" ml="1" variant="outline" fontSize="0.8em" colorScheme="teal">
-                  {launchEnvironment}
-                </Badge>{" "}
-                MultiversX Wallet
-              </ModalHeader>
-              <ModalCloseButton />
-              <ModalBody pb={6}>
-                <Stack spacing="5">
-                  <Box p="5px">
-                    <Stack>
-                      <Wrap spacing="20px" justify="space-between" padding="10px">
-                        <WrapItem onClick={() => goMxLogin(WALLETS.MX_XPORTALAPP)} className="auth_wrap">
-                          <WalletConnectLoginButton
-                            callbackRoute={"/"}
-                            loginButtonText={"xPortal App"}
-                            buttonClassName="auth_button"
-                            {...(walletConnectV2ProjectId ? { isWalletConnectV2: true } : {})}></WalletConnectLoginButton>
-                        </WrapItem>
+        <Modal isCentered size={modelSize} isOpen={isProgressModalOpen} onClose={handleProgressModalClose} closeOnEsc={false} closeOnOverlayClick={false}>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader>
+              Select a{" "}
+              <Badge mb="1" mr="1" ml="1" variant="outline" fontSize="0.8em" colorScheme="teal">
+                {launchEnvironment}
+              </Badge>{" "}
+              MultiversX Wallet
+            </ModalHeader>
+            <ModalCloseButton />
+            <ModalBody pb={6}>
+              <Stack spacing="5">
+                <Box p="5px">
+                  <Stack>
+                    <Wrap spacing="20px" justify="space-between" padding="10px">
+                      <WrapItem onClick={() => goMxLogin(WALLETS.MX_XPORTALAPP)} className="auth_wrap">
+                        <WalletConnectLoginButton
+                          callbackRoute={"/"}
+                          loginButtonText={"xPortal App"}
+                          buttonClassName="auth_button"
+                          {...(walletConnectV2ProjectId ? { isWalletConnectV2: true } : {})}></WalletConnectLoginButton>
+                      </WrapItem>
 
-                        <WrapItem onClick={() => goMxLogin(WALLETS.MX_DEFI)} className="auth_wrap">
-                          <ExtensionLoginButton callbackRoute={"/"} loginButtonText={"DeFi Wallet"} buttonClassName="auth_button"></ExtensionLoginButton>
-                        </WrapItem>
+                      <WrapItem onClick={() => goMxLogin(WALLETS.MX_DEFI)} className="auth_wrap">
+                        <ExtensionLoginButton callbackRoute={"/"} loginButtonText={"DeFi Wallet"} buttonClassName="auth_button"></ExtensionLoginButton>
+                      </WrapItem>
 
-                        <WrapItem onClick={() => goMxLogin(WALLETS.MX_WEBWALLET)} className="auth_wrap">
-                          <WebWalletLoginButton callbackRoute={"/"} loginButtonText={"Web Wallet"} buttonClassName="auth_button"></WebWalletLoginButton>
-                        </WrapItem>
+                      <WrapItem onClick={() => goMxLogin(WALLETS.MX_WEBWALLET)} className="auth_wrap">
+                        <WebWalletLoginButton callbackRoute={"/"} loginButtonText={"Web Wallet"} buttonClassName="auth_button"></WebWalletLoginButton>
+                      </WrapItem>
 
-                        <WrapItem onClick={() => goMxLogin(WALLETS.MX_LEDGER)} className="auth_wrap">
-                          <LedgerLoginButton callbackRoute={"/"} loginButtonText={"Ledger"} buttonClassName="auth_button"></LedgerLoginButton>
-                        </WrapItem>
-                      </Wrap>
-                    </Stack>
-                  </Box>
+                      <WrapItem onClick={() => goMxLogin(WALLETS.MX_LEDGER)} className="auth_wrap">
+                        <LedgerLoginButton callbackRoute={"/"} loginButtonText={"Ledger"} buttonClassName="auth_button"></LedgerLoginButton>
+                      </WrapItem>
+                    </Wrap>
+                  </Stack>
+                </Box>
 
-                  <Text fontSize="sm">
-                    By logging in, you are agreeing to the{" "}
-                    <Link href="https://itheum.com/termsofuse" isExternal>
-                      Terms of Use <ExternalLinkIcon mx="2px" />
-                    </Link>{" "}
-                    &{" "}
-                    <Link href="https://itheum.com/privacypolicy" isExternal>
-                      Privacy Policy <ExternalLinkIcon mx="2px" />
-                    </Link>
-                  </Text>
-                </Stack>
-              </ModalBody>
-            </ModalContent>
-          </Modal>
-        </Stack>
+                <Text fontSize="sm">
+                  By logging in, you are agreeing to the{" "}
+                  <Link href="https://itheum.com/termsofuse" isExternal>
+                    Terms of Use <ExternalLinkIcon mx="2px" />
+                  </Link>{" "}
+                  &{" "}
+                  <Link href="https://itheum.com/privacypolicy" isExternal>
+                    Privacy Policy <ExternalLinkIcon mx="2px" />
+                  </Link>
+                </Text>
+              </Stack>
+            </ModalBody>
+          </ModalContent>
+        </Modal>
       )}
     </>
   );

--- a/src/Launch/LandingPage.tsx
+++ b/src/Launch/LandingPage.tsx
@@ -30,7 +30,7 @@ import logoSmlL from "img/logo-sml-l.png";
 const dataDexVersion = process.env.REACT_APP_VERSION ? `v${process.env.REACT_APP_VERSION}` : "version number unknown";
 const nonProdEnv = `env:${process.env.REACT_APP_ENV_SENTRY_PROFILE}`;
 
-const AuthLauncher = ({ onLaunchMode }: { onLaunchMode: any }) => {
+const LandingPage = ({ onLaunchMode }: { onLaunchMode?: any }) => {
   const { colorMode } = useColorMode();
 
   let containerShadow = "rgb(255 255 255 / 16%) 0px 10px 36px 0px, rgb(255 255 255 / 6%) 0px 0px 0px 1px";
@@ -64,7 +64,7 @@ const AuthLauncher = ({ onLaunchMode }: { onLaunchMode: any }) => {
             </Heading>
           </HStack>
 
-          <PopupChainSelectorForWallet onMxEnvPick={onLaunchMode} />
+          {onLaunchMode && <PopupChainSelectorForWallet onMxEnvPick={onLaunchMode} />}
         </Flex>
 
         <Box backgroundColor={colorMode === "light" ? "white" : "black"} flexGrow="1">
@@ -256,4 +256,4 @@ const PopupChainSelectorForWallet = ({ onMxEnvPick }: { onMxEnvPick: any }) => {
   );
 };
 
-export default AuthLauncher;
+export default LandingPage;

--- a/src/libs/util.ts
+++ b/src/libs/util.ts
@@ -376,11 +376,8 @@ export const gtagGo = (category: string, action: any, label: any, value?: any) =
   }
 };
 
-export const clearAppSessions = () => {
-  // WEIRD, for some reason setWalletUsedSession(null) does not trigger the hook ONLY for metamask (works fine in mx)
-  // ... so we explicitly remove 'itm-wallet-used' here
+export const clearAppSessionsLaunchMode = () => {
   localStorage?.removeItem("itm-wallet-used");
-
   localStorage?.removeItem("itm-launch-mode");
   localStorage?.removeItem("itm-launch-env");
 };


### PR DESCRIPTION
hoisted out the launchmode logic so when in no-login view and user selects login, the wallet pick model appears on top of app and not is seperate black bg screen