### PR TITLE
fix on back button which made app crash

### DIFF
--- a/src/pages/GuardRails/components/guardRailsCards.tsx
+++ b/src/pages/GuardRails/components/guardRailsCards.tsx
@@ -28,9 +28,11 @@ export const GuardRailsCards: React.FC<Props> = (props) => {
   };
 
   const handlePrevClick = () => {
-    if (currentIndex < 2) {
+    if (currentIndex < 2 && currentIndex !== 0) {
       setCurrentIndex((prevIndex) => prevIndex + 1);
       setXPosition(xPosition - 400);
+    } else {
+      return null;
     }
   };
 


### PR DESCRIPTION
Quick fix on guard rails. Issue was even if the button back was disabled if you clicked on it made the app crash.