### PR TITLE
feature: disable data preview url check for bitz mint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-dex",
-  "version": "1.13.3",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-dex",
-      "version": "1.13.3",
+      "version": "1.13.5",
       "dependencies": {
         "@chakra-ui/icons": "2.1.1",
         "@chakra-ui/react": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-dex",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "The Itheum Data DEX enables you to trade your data using web3 tech",
   "dependencies": {
     "@chakra-ui/icons": "2.1.1",

--- a/src/pages/AdvertiseData/components/TradeForm.tsx
+++ b/src/pages/AdvertiseData/components/TradeForm.tsx
@@ -140,14 +140,14 @@ export const TradeForm: React.FC<TradeFormProps> = (props) => {
       .notOneOf(["https://drive.google.com"], `Data Preview URL doesn't accept Google Drive URLs`)
       .test("is-distinct", "Data Preview URL cannot be the same as the Data Stream URL", function (value) {
         return value !== this.parent.dataStreamUrlForm;
-      })
-      .test("is-200", "Data Stream URL must be public", async function (value: string) {
-        const { isSuccess, message } = await checkUrlReturns200(value);
-        if (!isSuccess) {
-          return this.createError({ message });
-        }
-        return true;
       }),
+    // .test("is-200", "Data Stream URL must be public", async function (value: string) {
+    //   const { isSuccess, message } = await checkUrlReturns200(value);
+    //   if (!isSuccess) {
+    //     return this.createError({ message });
+    //   }
+    //   return true;
+    // }),
 
     tokenNameForm: Yup.string()
       .required("Token name is required")


### PR DESCRIPTION
### Description

<!--- Describe your changes if needed -->

Why this change?
For bitz, we use data preview URL https://itheum.io/get_xp_stream_preview
Our 200 check is failing on this as it's making a async call to the url... i think we have to improve the data preview 200 check to just "ping" a url and no check if it can make an async call. for e.g. for security, our [itheum.io](http://itheum.io/) domain prevents async calls to it. which is a common scenario.
I uncommented the 200 check on data preview URL just for this mint, until we work out a long time fix

<!--- Leave testing instructions if needed -->

Check all boxes that apply and review your code if you can't tick them all yet:

- [ ] Did you test your changes in logged out, mainnet logged in and devnet logged in modes?
- [ ] Did you test your changes in mobile, tablet and desktop modes?
- [ ] Did you test your changes with or without the Itheum Web2 API availability? (don't forget about "graceful fallback")
- [ ] Did you use good user alerts and error messages? (and put them in language.ts)
- [ ] Did you leave the code base cleaner than you found it overall (done reasonable refactoring efforts wherever you felt that was needed)?
