### PR TITLE
fix: refreshing the liveliness page would disable the reinvest button

### DIFF
--- a/src/components/Liveliness/LivelinessStakingSol.tsx
+++ b/src/components/Liveliness/LivelinessStakingSol.tsx
@@ -196,13 +196,13 @@ export const LivelinessStakingSol: React.FC = () => {
   }, [numberOfBonds]);
 
   useEffect(() => {
-    if (nftMeIdBond && solNfts && userPublicKey) {
+    if (nftMeIdBond && solNfts.length > 0 && userPublicKey) {
       const _nftMeId = solNfts.find((nft) => nft.id == nftMeIdBond.assetId.toString());
       if (_nftMeId === undefined) console.error("NftMeID has not been found");
       setNftMeId(_nftMeId);
       setAllInfoLoading(false);
     }
-  }, [nftMeIdBond]);
+  }, [nftMeIdBond, solNfts]);
 
   // rewardsPerShare, accumulatedRewards, lastRewardSlot,  rewardsPerSlot, rewardsReserve, rewardsPerShare, maxApr, rewardsState
   useEffect(() => {
@@ -280,6 +280,7 @@ export const LivelinessStakingSol: React.FC = () => {
       }
     }
   }
+
   async function fetchBonds() {
     if (numberOfBonds && userPublicKey && programSol) {
       retrieveBondsAndNftMeIdVault(userPublicKey, numberOfBonds, programSol).then(({ bonds, nftMeIdVault, weightedLivelinessScore }) => {
@@ -293,6 +294,7 @@ export const LivelinessStakingSol: React.FC = () => {
       });
     }
   }
+
   async function sendAndConfirmTransaction({
     transaction,
     customErrorMessage = "Transaction failed",

--- a/src/libs/Solana/utils.ts
+++ b/src/libs/Solana/utils.ts
@@ -6,10 +6,9 @@ import { SPL_ACCOUNT_COMPRESSION_PROGRAM_ID } from "@solana/spl-account-compress
 import { ASSOCIATED_TOKEN_PROGRAM_ID, getAssociatedTokenAddress, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { AccountMeta, Connection, PublicKey, Transaction } from "@solana/web3.js";
 import BigNumber from "bignumber.js";
-import { contractsForChain, IS_DEVNET } from "libs/config";
 import { getApiDataDex } from "libs/utils";
 
-import { BOND_CONFIG_INDEX, BONDING_PROGRAM_ID, SolEnvEnum } from "./config";
+import { BOND_CONFIG_INDEX, BONDING_PROGRAM_ID } from "./config";
 import { CoreSolBondStakeSc, IDL } from "./CoreSolBondStakeSc";
 import { Bond } from "./types";
 


### PR DESCRIPTION
### Description

<!--- Describe your changes if needed -->

<!--- Leave testing instructions if needed -->

Check all boxes that apply and review your code if you can't tick them all yet:

- [ ] Did you test your changes in logged out, mainnet logged in and devnet logged in modes?
- [ ] Did you test your changes in mobile, tablet and desktop modes?
- [ ] Did you test your changes with or without the Itheum Web2 API availability? (don't forget about "graceful fallback")
- [ ] Did you use good user alerts and error messages? (and put them in language.ts)
- [ ] Did you leave the code base cleaner than you found it overall (done reasonable refactoring efforts wherever you felt that was needed)?
